### PR TITLE
fix mongo data volume location on the readme

### DIFF
--- a/Alpine-Mongo/README.md
+++ b/Alpine-Mongo/README.md
@@ -3,7 +3,7 @@
 This repository contains Dockerfile for [MongoDB 3.4](https://www.mongodb.org)
 container, based on the Alpine 3.6 image.
 
-**Author** 
+**Author**
 
 * Updated By: [Shikhir Singh](http://www.shikhir.com/)
 
@@ -33,7 +33,7 @@ You can also specify the database repository where to store the data
 with the volume -v option:
 
     $ docker run -d --name mongo -p 27017:27017 \
-	  -v /somewhere/onmyhost/mydatabase:/data/db \
+	  -v /somewhere/onmyhost/mydatabase:/data/mongodb \
 	  shikhir/alpine-mongodb
 
 To run a shell session:
@@ -44,7 +44,7 @@ To use the mongo shell client:
 
 	$ docker exec -ti mongo mongo
 
-The mongo shell client can also be run its own container: 
+The mongo shell client can also be run its own container:
 
 	$ docker run -ti --rm --name mongoshell monogo host:port/db
 


### PR DESCRIPTION
This was certainly a typo, real path in container for mongo data is `/data/mongodb`